### PR TITLE
WeekView Item Drag & Drop 안되도록 수정

### DIFF
--- a/core/src/main/java/com/alamkanak/weekview/WeekViewGestureHandler.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekViewGestureHandler.kt
@@ -146,7 +146,7 @@ internal class WeekViewGestureHandler(
 
         val longClickResult = touchHandler.handleLongClick(e.x, e.y) ?: return
         if (!longClickResult.handled) {
-            dragHandler.startDragAndDrop(longClickResult.eventChip, e.x, e.y)
+//            dragHandler.startDragAndDrop(longClickResult.eventChip, e.x, e.y)
         }
     }
 
@@ -193,6 +193,7 @@ internal class WeekViewGestureHandler(
     }
 
     fun onTouchEvent(event: MotionEvent): Boolean {
+
         if (!scrollDirection.isHorizontal && flingDirection == None) {
             scaleDetector.onTouchEvent(event)
         }
@@ -207,13 +208,13 @@ internal class WeekViewGestureHandler(
             preFlingFirstVisibleDate = viewState.firstVisibleDate.copy()
         }
 
-        if (event.action == ACTION_MOVE && dragHandler.isDragging) {
-            dragHandler.updateDragAndDrop(event)
-        }
-
-        if (event.action == ACTION_UP && dragHandler.isDragging) {
-            dragHandler.finishDragAndDrop()
-        }
+//        if (event.action == ACTION_MOVE && dragHandler.isDragging) {
+//            dragHandler.updateDragAndDrop(event)
+//        }
+//
+//        if (event.action == ACTION_UP && dragHandler.isDragging) {
+//            dragHandler.finishDragAndDrop()
+//        }
 
         return handled
     }


### PR DESCRIPTION
## 수정 내역
- 기본적으로 아이템 drag & drop 사용되도록 되어 있으면 드래그 시 아이템의 시작 시간, 끝 시간이 바뀌어서, 사용 안하는 설정 옵션이 따로 없어 사용안하도록 수정하였음